### PR TITLE
idempotent Parse - req body is no longer 'consumed' with Parse

### DIFF
--- a/githubhook.go
+++ b/githubhook.go
@@ -2,6 +2,7 @@
 package githubhook
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
@@ -86,6 +87,8 @@ func New(req *http.Request) (hook *Hook, err error) {
 	}
 
 	hook.Payload, err = ioutil.ReadAll(req.Body)
+
+	req.Body = ioutil.NopCloser(bytes.NewBuffer(hook.Payload))
 	return
 }
 

--- a/githubhook_test.go
+++ b/githubhook_test.go
@@ -81,3 +81,21 @@ func TestValidSignature(t *testing.T) {
 		t.Error(fmt.Sprintf("Unexpected error '%s'", err))
 	}
 }
+
+func TestIdempotent(t *testing.T) {
+
+	body := "{}"
+
+	r, _ := http.NewRequest("POST", "/path", strings.NewReader(body))
+	r.Header.Add("x-hub-signature", signature(body))
+	r.Header.Add("x-github-event", "bogus event")
+	r.Header.Add("x-github-delivery", "bogus id")
+
+	if _, err := githubhook.Parse([]byte(testSecret), r); err != nil {
+		t.Error(fmt.Sprintf("Unexpected error '%s'", err))
+	}
+
+	if _, err := githubhook.Parse([]byte(testSecret), r); err != nil {
+		t.Error(fmt.Sprintf("Unexpected error '%s'", err))
+	}
+}


### PR DESCRIPTION
Parse should not affect `req` that is passed to it.