### PR TITLE
Travis out, actions in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Go
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.7", "1.x"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Test
+        run: go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
----
-language: go
-go: 1.4

--- a/githubhook_test.go
+++ b/githubhook_test.go
@@ -1,11 +1,10 @@
-package githubhook_test
+package githubhook
 
 import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"github.com/rjz/githubhook"
 	"net/http"
 	"strings"
 	"testing"
@@ -20,12 +19,12 @@ func expectErrorMessage(t *testing.T, msg string, err error) {
 }
 
 func expectNewError(t *testing.T, msg string, r *http.Request) {
-	_, err := githubhook.New(r)
+	_, err := New(r)
 	expectErrorMessage(t, msg, err)
 }
 
 func expectParseError(t *testing.T, msg string, r *http.Request) {
-	_, err := githubhook.Parse([]byte(testSecret), r)
+	_, err := Parse([]byte(testSecret), r)
 	expectErrorMessage(t, msg, err)
 }
 
@@ -77,7 +76,7 @@ func TestValidSignature(t *testing.T) {
 	r.Header.Add("x-github-event", "bogus event")
 	r.Header.Add("x-github-delivery", "bogus id")
 
-	if _, err := githubhook.Parse([]byte(testSecret), r); err != nil {
+	if _, err := Parse([]byte(testSecret), r); err != nil {
 		t.Error(fmt.Sprintf("Unexpected error '%s'", err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rjz/githubhook
+
+go 1.4

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/rjz/githubhook
 
-go 1.4
+go 1.7


### PR DESCRIPTION
This change introduces an alternate CI platform (aka Github Actions) since the demise of Travis's free tier.